### PR TITLE
New parameter + clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The output of the package are the tweets downloaded as a [tibble](https://CRAN.R
 
 This package limits the rate of tweet downloading so Twitter's 90,000 tweet/15 minute limit is not exceeded. If you choose to download the tweets to JSON files, then a new JSON file will be created for every 90,000 tweet ID numbers.
 
-Tweets that have been delete or made private cannot be downloaded.
+Tweets that have been deleted or made private cannot be downloaded.
 
 ## Getting Started
 

--- a/man/rehydratoR.Rd
+++ b/man/rehydratoR.Rd
@@ -22,8 +22,7 @@ rehydratoR(consumer_key, consumer_secret, access_token, access_secret,
 write the tweets to files instead of returning the tweets as a variable.}
 }
 \value{
-A tibble of tweets data if base_path is not defined. Nothing is returned if base_path is defined
-  but the tweets are saved to a file for about every 90,0000 tweets.
+A tibble of tweets data if base_path is not defined. Nothing is returned if base_path is defined; in that case, the tweets are saved to a file for about every 90,0000 tweets.
 }
 \description{
 Get tweets for given statuses (tweet IDs).


### PR DESCRIPTION
I added a parameter called group_start to rehydratoR.  It takes the list of split tweet IDs and keeps only those from group_start to the final list.  That way, if a download is interrupted, which is likely for large corpuses, the user can restart the download at the group_start chunk, not from the beginning.

I added a line to print an estimate of how long a download will take. 

Somewhere, "delete" should have read "deleted", so I fixed.

I found a sentence in the manual unclear, so I slightly modified it.